### PR TITLE
Add Colors via ANSI Escape Codes on Linux/OSX/Windows

### DIFF
--- a/accessories.h
+++ b/accessories.h
@@ -14,6 +14,37 @@ std::map<int, int> my_dictionary = {
     {4, 16}     // [4] Hexadecimal (Base 16)
 };
 
+// ANSI Escape Codes
+// Insert into STD_OUT to format text with color, bold, etc.
+// https://en.wikipedia.org/wiki/ANSI_escape_code
+#define ANSI_RESET "\u001b[0m"
+#define ANSI_RED "\u001b[31m"
+#define ANSI_GREEN "\u001b[32m"
+#define ANSI_YELLOW "\u001b[33m"
+#define ANSI_BLUE "\u001b[34m"
+#define ANSI_MAGENTA "\u001b[35m"
+#define ANSI_CYAN "\u001b[36m"
+#define ANSI_WHITE "\u001b[37m"
+#define ANSI_GRAY "\u001b[38;5;250m"
+#define ANSI_BRIGHT_RED "\u001b[31;1m"
+#define ANSI_BRIGHT_GREEN "\u001b[38;5;10m"
+#define ANSI_BRIGHT_YELLOW "\u001b[33;1m"
+#define ANSI_BRIGHT_BLUE "\u001b[34;1m"
+#define ANSI_BRIGHT_MAGENTA "\u001b[35;1m"
+#define ANSI_BRIGHT_CYAN "\u001b[36;1m"
+#define ANSI_BRIGHT_WHITE "\u001b[37;1m"
+#define ANSI_HIGHLIGHT_RED "\u001b[41m"
+#define ANSI_HIGHLIGHT_DULL_RED "\u001b[48;5;88m"
+#define ANSI_HIGHLIGHT_GREEN "\u001b[42m"
+#define ANSI_HIGHLIGHT_DULL_GREEN "\u001b[48;5;22m"
+#define ANSI_HIGHLIGHT_YELLOW "\u001b[43m"
+#define ANSI_HIGHLIGHT_BLUE "\u001b[44m"
+#define ANSI_HIGHLIGHT_MAGENTA "\u001b[45m"
+#define ANSI_HIGHLIGHT_CYAN "\u001b[46m"
+#define ANSI_HIGHLIGHT_WHITE "\u001b[47m"
+#define ANSI_BOLD "\u001b[1m"
+#define ANSI_UNDERLINE "\u001b[4m"
+#define ANSI_REVERSE "\u001b[7m"
 
 
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -15,8 +15,8 @@ using namespace std;
 
 int main()
 {
-    cout << "WELCOME TO THE DATA CONVERTER" << endl;
-    cout << "--------------------------------" << endl;
+    cout << ANSI_BOLD << ANSI_UNDERLINE << ANSI_GREEN << "WELCOME TO THE DATA CONVERTER" << ANSI_RESET << endl;
+    cout << ANSI_BOLD << ANSI_GREEN  << "--------------------------------" << ANSI_RESET << endl;
 
     char continueProgram = 'Y';
 
@@ -24,11 +24,15 @@ int main()
     {
         // ================================ TAKING IN INPUT ================================
         int input_choice;
-        cout << "[1] Decimal (Base 10)\n[2] Binary (Base 2)\n[3] Octal (Base 8)\n[4] Hexadecimal (Base 16)\n";
-        cout << "Please pick your input type: ";
+        cout << ANSI_BRIGHT_WHITE << ANSI_BOLD << "[1]" << ANSI_RESET << " Decimal (Base 10)\n"
+             << ANSI_BRIGHT_WHITE << ANSI_BOLD << "[2]" << ANSI_RESET << " Binary (Base 2)\n"
+             << ANSI_BRIGHT_WHITE << ANSI_BOLD << "[3]" << ANSI_RESET << " Octal (Base 8)\n"
+             << ANSI_BRIGHT_WHITE << ANSI_BOLD << "[4]" << ANSI_RESET << " Hexadecimal (Base 16)\n";
+        cout << "Please pick your input type: " << ANSI_BOLD << ANSI_BRIGHT_GREEN << ANSI_HIGHLIGHT_DULL_GREEN;
 
         cin >> input_choice;
         cin.ignore();
+        cout << ANSI_RESET;
 
         string base_str;
         int decimal;
@@ -44,15 +48,18 @@ int main()
             // Any base to decimal
             if (input_choice == 2)
             {
-                cout << "Input a binary string: ";
+                cout << "Input a binary string: "
+                     << ANSI_BOLD << ANSI_BRIGHT_GREEN << ANSI_HIGHLIGHT_DULL_GREEN;
             }
             else if (input_choice == 3)
             {
-                cout << "Input an octal string: ";
+                cout << "Input an octal string: "
+                     << ANSI_BOLD << ANSI_BRIGHT_GREEN << ANSI_HIGHLIGHT_DULL_GREEN;
             }
             else // if input_choice == 4
             {
-                cout << "Input a hexadecimal string: ";
+                cout << "Input a hexadecimal string: "
+                     << ANSI_BOLD << ANSI_BRIGHT_GREEN << ANSI_HIGHLIGHT_DULL_GREEN;
             }
             getline(cin, base_str);
         }
@@ -64,8 +71,10 @@ int main()
         // ================================ TAKING IN OUTPUT ================================
         int output_choice;
         
-        cout << "Please pick what output type you want to convert your input to: ";
+        cout << "Please pick what output type you want to convert your input to: " 
+             << ANSI_BOLD << ANSI_BRIGHT_GREEN << ANSI_HIGHLIGHT_DULL_GREEN;
         cin >> output_choice;
+        cout << ANSI_RESET;
 
         cout << "Base " << my_dictionary[input_choice] << " converted to base " << my_dictionary[output_choice] << ": ";
         if (input_choice == output_choice)

--- a/main.cpp
+++ b/main.cpp
@@ -13,8 +13,24 @@ using namespace std;
 #include "functions.h"
 #include "accessories.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#include <fcntl.h>
+#endif
+
 int main()
 {
+
+    #ifdef _WIN32
+    // Attempt to enable ANSI Escape Sequence on Windows
+    HANDLE hStdIn;
+    DWORD mode;
+    hStdIn = GetStdHandle(STD_OUTPUT_HANDLE);
+    GetConsoleMode(hStdIn, &mode);
+    mode |= 0x0004;
+    SetConsoleMode(hStdIn, mode);
+	#endif
+
     cout << ANSI_BOLD << ANSI_UNDERLINE << ANSI_GREEN << "WELCOME TO THE DATA CONVERTER" << ANSI_RESET << endl;
     cout << ANSI_BOLD << ANSI_GREEN  << "--------------------------------" << ANSI_RESET << endl;
 
@@ -109,7 +125,12 @@ int main()
 
         cout << "Do you want to continue this program? (y/n) ";
         cin >> continueProgram;
+        
+        #ifdef _WIN32
+        system("cls");
+        #else
         system("clear");
+        #endif
     }
 
     cout << "Have a great day!" << endl;


### PR DESCRIPTION
## Description
Add color support to the application UI using [ANSI Escape Codes](https://en.wikipedia.org/wiki/ANSI_escape_code). ANSI Escape Codes are widely supported by default on all Unix-like systems, including Linux and OSX. While support is not as common on Windows, recent versions of Windows 10 and all versions of the upcoming Windows 11 offer optional support by setting a flag on STD_OUT.<br>
This PR adds the ANSI Escape Code definitions to accessories.h, and then uses them to do some basic coloring of the UI.
* Resolves #1 

## UI Preview
![image](https://user-images.githubusercontent.com/46112489/166116399-4221cd31-7cc3-45fb-90f5-2a2f527539f9.png)

## Testing
Tested on Windows + Linux
<br>